### PR TITLE
토큰 기반 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,16 +24,19 @@ repositories {
 }
 
 dependencies {
-	// implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
-	// testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/kr/co/khedu/fitroutine/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/khedu/fitroutine/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package kr.co.khedu.fitroutine.auth.controller;
+
+import kr.co.khedu.fitroutine.auth.model.dto.LoginRequest;
+import kr.co.khedu.fitroutine.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public final class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/auth/model/dto/LoginRequest.java
+++ b/src/main/java/kr/co/khedu/fitroutine/auth/model/dto/LoginRequest.java
@@ -1,0 +1,19 @@
+package kr.co.khedu.fitroutine.auth.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public final class LoginRequest {
+    private final String email;
+    private final String password;
+
+    @Builder
+    private LoginRequest(
+            String email,
+            String password
+    ) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/auth/model/dto/LoginResponse.java
+++ b/src/main/java/kr/co/khedu/fitroutine/auth/model/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package kr.co.khedu.fitroutine.auth.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public final class LoginResponse {
+    private final String accessToken;
+
+    @Builder
+    private LoginResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/auth/service/AuthService.java
+++ b/src/main/java/kr/co/khedu/fitroutine/auth/service/AuthService.java
@@ -1,0 +1,40 @@
+package kr.co.khedu.fitroutine.auth.service;
+
+import kr.co.khedu.fitroutine.auth.model.dto.LoginRequest;
+import kr.co.khedu.fitroutine.auth.model.dto.LoginResponse;
+import kr.co.khedu.fitroutine.member.mapper.MemberMapper;
+import kr.co.khedu.fitroutine.member.model.vo.Member;
+import kr.co.khedu.fitroutine.security.jwt.JwtTokenProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AuthService {
+    private final MemberMapper memberMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(
+            MemberMapper memberMapper,
+            PasswordEncoder passwordEncoder,
+            JwtTokenProvider jwtTokenProvider
+    ) {
+        this.memberMapper = memberMapper;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public LoginResponse login(LoginRequest request) {
+        Member member = memberMapper.findMemberByEmail(request.getEmail());
+
+        if (member == null || passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new IllegalStateException("이메일 또는 비밀번호가 틀렸습니다.");
+        }
+
+        return LoginResponse.builder()
+                .accessToken(jwtTokenProvider.generateToken(member.getEmail()))
+                .build();
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/config/SecurityConfig.java
+++ b/src/main/java/kr/co/khedu/fitroutine/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package kr.co.khedu.fitroutine.config;
+
+import kr.co.khedu.fitroutine.security.jwt.JwtAuthenticationFilter;
+import kr.co.khedu.fitroutine.security.jwt.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    public SecurityConfig(
+            JwtTokenProvider jwtTokenProvider,
+            UserDetailsService userDetailsService
+    ) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(registry ->
+                        registry
+                                .requestMatchers("/auth/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .sessionManagement(configurer ->
+                        configurer
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(
+                        jwtAuthenticationFilter(),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/member/mapper/MemberMapper.java
+++ b/src/main/java/kr/co/khedu/fitroutine/member/mapper/MemberMapper.java
@@ -1,5 +1,6 @@
 package kr.co.khedu.fitroutine.member.mapper;
 
+import jakarta.annotation.Nullable;
 import kr.co.khedu.fitroutine.member.model.dto.MemberEditInfo;
 import kr.co.khedu.fitroutine.member.model.dto.MemberProfile;
 import kr.co.khedu.fitroutine.member.model.vo.Member;
@@ -7,6 +8,8 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface MemberMapper {
+    @Nullable Member findMemberByEmail(String email);
+
     Member findMemberByBlogId(long blogId);
 
     MemberProfile getMemberProfile(long memberId);

--- a/src/main/java/kr/co/khedu/fitroutine/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/kr/co/khedu/fitroutine/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package kr.co.khedu.fitroutine.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public final class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(
+            JwtTokenProvider jwtTokenProvider,
+            UserDetailsService userDetailsService
+    ) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7);
+        if (jwtTokenProvider.isTokenExpired(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(
+                jwtTokenProvider.extractEmail(token)
+        );
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+        authentication.setDetails(
+                new WebAuthenticationDetailsSource().buildDetails(request)
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/co/khedu/fitroutine/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,59 @@
+package kr.co.khedu.fitroutine.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Service
+public final class JwtTokenProvider {
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret-key}") String secretKey,
+            @Value("${jwt.expiration}") long expiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.expiration = expiration;
+    }
+
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        String email = extractClaims(token).getSubject();
+        if (email == null) {
+            throw new IllegalStateException("JWT의 sub 값은 null이 아니어야 합니다.");
+        }
+
+        return email;
+    }
+
+    public boolean isTokenExpired(String token) {
+        Date expiration = extractClaims(token).getExpiration();
+        if (expiration == null) {
+            throw new IllegalStateException("JWT의 exp 값은 null이 아니어야 합니다.");
+        }
+
+        return expiration.before(new Date());
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/security/model/dto/UserDetailsImpl.java
+++ b/src/main/java/kr/co/khedu/fitroutine/security/model/dto/UserDetailsImpl.java
@@ -1,0 +1,37 @@
+package kr.co.khedu.fitroutine.security.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public final class UserDetailsImpl implements UserDetails {
+    private final long memberId;
+    private final String email;
+    private final String password;
+
+    @Builder
+    private UserDetailsImpl(
+            long memberId,
+            String email,
+            String password
+    ) {
+        this.memberId = memberId;
+        this.email = email;
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+}

--- a/src/main/java/kr/co/khedu/fitroutine/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/kr/co/khedu/fitroutine/security/service/UserDetailsServiceImpl.java
@@ -1,0 +1,33 @@
+package kr.co.khedu.fitroutine.security.service;
+
+import kr.co.khedu.fitroutine.member.mapper.MemberMapper;
+import kr.co.khedu.fitroutine.member.model.vo.Member;
+import kr.co.khedu.fitroutine.security.model.dto.UserDetailsImpl;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public final class UserDetailsServiceImpl implements UserDetailsService {
+    private final MemberMapper memberMapper;
+
+    public UserDetailsServiceImpl(MemberMapper memberMapper) {
+        this.memberMapper = memberMapper;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberMapper.findMemberByEmail(username);
+
+        if (member == null) {
+            throw new UsernameNotFoundException(username);
+        }
+
+        return UserDetailsImpl.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,4 +13,7 @@ mybatis.mapper-locations=classpath:mapper/**/*.xml
 spring.sql.init.continue-on-error=true
 spring.sql.init.mode=never
 
+jwt.secret-key=${JWT_SECRET_KEY}
+jwt.expiration=${JWT_EXPIRATION}
+
 client.origins=http://localhost:3000

--- a/src/main/resources/mapper/member-mapper.xml
+++ b/src/main/resources/mapper/member-mapper.xml
@@ -3,6 +3,11 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//KO"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="kr.co.khedu.fitroutine.member.mapper.MemberMapper">
+    <select id="findMemberByEmail" resultType="kr.co.khedu.fitroutine.member.model.vo.Member">
+        SELECT *
+        FROM TB_MEMBER
+        WHERE EMAIL = #{email}
+    </select>
     <select id="findMemberByBlogId" resultType="kr.co.khedu.fitroutine.member.model.vo.Member">
         SELECT *
         FROM TB_MEMBER M


### PR DESCRIPTION
## 개요

토큰 기반 로그인이 구현되었습니다. 이제 `/auth` 아래가 아닌 모든 엔드포인트에 대한 요청은 토큰이 필요합니다. 또한 **Refresh Token**은 추후에 구현할 예정입니다. 현재는 로그인 후 일정 시간이 지나면 만료됩니다.


## `.env` 설정

병합 후 각자 로컬 프로젝트에서 `.env` 파일에 `JWT_SECRET_KEY`, `JWT_EXPIRATION` 값을 설정하셔야 합니다. 예시는 다음과 같습니다.

```
JWT_SECRET_KEY=HNckRT4RJMmEAEnXDoDU1nPWwQslfxAcXOH7bVvPdwM=
JWT_EXPIRATION=86400000
```

## `Controller`에서 `Claims`에 접근

토큰에 저장된 정보들을 얻는 방법의 예시는 다음과 같습니다.

```java
@GetMapping("/me")
public ResponseEntity<?> getMemberProfile(
        // 헤더에서 private claims 얻기
        @AuthenticationPrincipal UserDetailsImpl userDetails
) {
    // private claims에서 memberId 얻기
    long memberId = userDetails.getMemberId();

    return ResponseEntity.ok(memberService.getMemberProfile(memberId));
}
```
    