### PR TITLE
tb_todo 테이블의 권장 일일 소모 칼로리 컬럼 삭제

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -87,7 +87,6 @@ CREATE TABLE TB_TODO
     ENDED_AT    DATE   NOT NULL,
     PURPOSE     VARCHAR2(30) CHECK (PURPOSE IN ('ENDURANCE', 'STRENGTH', 'MAINTENANCE', 'DIET')) NOT NULL,
     CATEGORY    VARCHAR2(8)                                                                      NOT NULL,
-    DAY_KCAL    NUMBER,
     DAY_REPEAT  NUMBER,
     TDEE        NUMBER,
     GOAL_WEIGHT NUMBER,


### PR DESCRIPTION
권장 일일 소모 칼로리를 사용자의 tdee, 목표무게, 목표날짜, 현재 신체 정보 등을 통해 계산이 가능하고,
사용되는 부분도 다이어트 목적일시 메뉴,운동을 선택할때만 사용되기에 삭제하기로 결정했습니다.